### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Generate App Bundle
@@ -46,6 +49,9 @@ jobs:
     name: Release App Bundle
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Download AAB from build
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Potential fix for [https://github.com/PKopel/MemoirStats/security/code-scanning/3](https://github.com/PKopel/MemoirStats/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. At the workflow level, we will set `contents: read` as the default permission, which is sufficient for most steps. For the `release` job, we will override the permissions to include `contents: write` and `packages: write`, as these are required for creating a release and uploading assets. This approach minimizes permissions while ensuring the workflow functions correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
