### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Generate App Bundle
@@ -43,6 +46,8 @@ jobs:
           path: ${{steps.sign_aab.outputs.signedReleaseFile}}
 
   release:
+    permissions:
+      contents: write
     name: Release App Bundle
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/PKopel/MemoirStats/security/code-scanning/1](https://github.com/PKopel/MemoirStats/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimal permissions required for each job. For the `build` job, we will use `contents: read` since it primarily involves reading repository contents and uploading artifacts. For the `release` job, we will add `contents: read` and `contents: write` because it creates a release and uploads assets, which require write access to repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
